### PR TITLE
Update GPG key installation step to the latest

### DIFF
--- a/docker/Dockerfile.x86_64.base
+++ b/docker/Dockerfile.x86_64.base
@@ -137,7 +137,8 @@ RUN apt update \
     && apt-key adv --keyserver keys.gnupg.net --recv-key F6E65AC044F831AC80A06380C8B3A55A6F3EFCDE \
     || apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key F6E65AC044F831AC80A06380C8B3A55A6F3EFCDE \
     && add-apt-repository -y "deb https://librealsense.intel.com/Debian/apt-repo bionic main" -u \
-    && apt-get install -y librealsense2-utils librealsense2-dev
+    && apt-get install -y librealsense2-utils librealsense2-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install Tao converter
 RUN mkdir -p /opt/nvidia/tao && \

--- a/docker/Dockerfile.x86_64.base
+++ b/docker/Dockerfile.x86_64.base
@@ -109,8 +109,8 @@ RUN locale-gen en_US en_US.UTF-8
 RUN update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
 ENV LANG=en_US.UTF-8
 
-RUN curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
-RUN sh -c 'echo "deb [arch=$(dpkg --print-architecture)] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2-latest.list'
+RUN curl -sS https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
+RUN sh -c 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2.list'
 
 RUN apt-get update && apt-get install -y \
         python3-colcon-common-extensions \


### PR DESCRIPTION
Some of the ROS installation instructions have been updated.
This PR updates the GPG key installation step to the latest.

ref: https://github.com/ros2/ros2_documentation/pull/1189
ref: https://github.com/dusty-nv/jetson-containers/pull/67