### PR TITLE
Fix compatibility with ros2 galactic

### DIFF
--- a/isaac_ros_common/src/vpi_utilities.cpp
+++ b/isaac_ros_common/src/vpi_utilities.cpp
@@ -69,7 +69,7 @@ uint32_t DeclareVPIBackendParameter(rclcpp::Node * node, uint32_t default_backen
           os << entry.first << std::endl;
         });
 
-      RCLCPP_ERROR(node->get_logger(), os.str());
+      RCLCPP_ERROR(node->get_logger(), os.str().c_str());
 
       // Return default backends due to error
       return default_backends;


### PR DESCRIPTION
RCLCPP macros no longer accept std::string