### PR TITLE
added user_id to usermod

### DIFF
--- a/docker/Dockerfile.x86_64.base
+++ b/docker/Dockerfile.x86_64.base
@@ -183,7 +183,7 @@ ARG USER_GID=1000
 
 # Create the 'admin' user
 RUN groupmod --gid ${USER_GID} -n ${USERNAME} triton-server \
-    && usermod -l ${USERNAME} -m -d /home/${USERNAME} triton-server \
+    && usermod -l ${USERNAME} -u ${USER_UID} -m -d /home/${USERNAME} triton-server \
     && mkdir -p /home/${USERNAME} \
     && sudo chown ${USERNAME}:${USERNAME} /home/${USERNAME} \
     && echo ${USERNAME} ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/${USERNAME} \


### PR DESCRIPTION
After setting the ROS_DOMAIN_ID inside the container and on the host network to the same value, the topics published inside the container were not visible outside the container. This is because the UID inside the container didn't match with the one of the host.