### PR TITLE
Add ament_cmake_auto as build dep

### DIFF
--- a/isaac_ros_apriltag_interfaces/package.xml
+++ b/isaac_ros_apriltag_interfaces/package.xml
@@ -20,6 +20,7 @@ license agreement from NVIDIA CORPORATION is strictly prohibited.
   <author>Arjun Bhorkar</author>
   <author>Hemal Shah</author>
 
+  <build_depend>ament_cmake_auto</build_depend>
   <build_depend>rosidl_default_generators</build_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 


### PR DESCRIPTION
Hi!

This fixes a small issue found when trying to compile the project from source alongside ROS 2 core packages. The package ament_cmake_auto is required inside isaac_ros_apriltag_interfaces [CMakeLists.txt](https://github.com/NVIDIA-ISAAC-ROS/isaac_ros_common/blob/main/isaac_ros_apriltag_interfaces/CMakeLists.txt#L27), but it is not listed as build dependency in the package.xml. This way, colcon may try to build isaac_ros_apriltag_interfaces before ament_cmake_auto was built, resulting in an error.

This PR adds ament_cmake_auto as build dependency, thus informing colcon the correct order to build the packages

