### PR TITLE
Revert Isaac ROS Dev base image for aarch64

### DIFF
--- a/docker/Dockerfile.aarch64.humble.nav2
+++ b/docker/Dockerfile.aarch64.humble.nav2
@@ -6,4 +6,4 @@
 # distribution of this software and related documentation without an express
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 
-FROM nvcr.io/nvidia/isaac/ros:aarch64-humble-nav2_c2befe2b1d90532fc15ef72650ccd7b0
+FROM nvcr.io/nvidia/isaac/ros:aarch64-humble-nav2_6dfaf7adbe190f1181c3a0a2f2418760


### PR DESCRIPTION
Reverting change to aarch64 image introduced in https://github.com/NVIDIA-ISAAC-ROS/isaac_ros_common/commit/429f6b438377d408428d2daaa5fcbbcc21cf5d6b which is causing issues with newer setuptools version:

https://github.com/NVIDIA-ISAAC-ROS/isaac_ros_visual_slam/issues/71 https://github.com/NVIDIA-ISAAC-ROS/isaac_ros_apriltag/issues/21

Signed-off-by: Hemal Shah <77975110+hemalshahNV@users.noreply.github.com>