### PR TITLE
Update build_base_image.sh to run successfully on Jetson Orin Nano Developer Kit

### DIFF
--- a/scripts/build_base_image.sh
+++ b/scripts/build_base_image.sh
@@ -152,7 +152,7 @@ fi
 
 if [[ "$PLATFORM" == "aarch64" ]]; then
     # Make sure the nvidia docker runtime will be used for builds
-    DEFAULT_RUNTIME=$(docker info | grep "Default Runtime: nvidia" ; true)
+    DEFAULT_RUNTIME=$(docker info | grep "Runtimes: io.containerd.runc.v2 io.containerd.runtime.v1.linux nvidia runc" ; true)
     if [[ -z "$DEFAULT_RUNTIME" ]]; then
         print_error "Default docker runtime is not nvidia!, please make sure the following line is"
         print_error "present in /etc/docker/daemon.json"


### PR DESCRIPTION
When I ran the `scripts/run_dev.sh`, I found the error below.

```
$ ./scripts/run_dev.sh ${ISAAC_ROS_WS}
Error: Failed to call git rev-parse --git-dir: exit status 128 
Building aarch64.ros2_humble.realsense.user base as image: isaac_ros_dev-aarch64 using key aarch64.ros2_humble.realsense.user
Using base image name not specified, using ''
Using docker context dir not specified, using Dockerfile directory
Default docker runtime is not nvidia!, please make sure the following line is
present in /etc/docker/daemon.json
"default-runtime": "nvidia",

And then restart the docker daemon
Failed to build base image: isaac_ros_dev-aarch64, aborting.
```

I think the docker runtimes information was changed.

```
$ docker info | grep Runtimes
 Runtimes: io.containerd.runc.v2 io.containerd.runtime.v1.linux nvidia runc
```

After applying this PR's change,  `scripts/run_dev.sh` works correctly.