### PR TITLE
Fix isaac_ros-dev path by using relative path to script

### DIFF
--- a/scripts/run_dev.sh
+++ b/scripts/run_dev.sh
@@ -28,7 +28,7 @@ ISAAC_ROS_DEV_DIR="$1"
 if [[ -z "$ISAAC_ROS_DEV_DIR" ]]; then
     ISAAC_ROS_DEV_DIR="$HOME/workspaces/isaac_ros-dev"
     if [[ ! -d "$ISAAC_ROS_DEV_DIR" ]]; then
-        ISAAC_ROS_DEV_DIR=$(pwd)
+        ISAAC_ROS_DEV_DIR="$ROOT/../../.."
     fi
     print_warning "isaac_ros_dev not specified, assuming $ISAAC_ROS_DEV_DIR"
 else
@@ -80,7 +80,7 @@ fi
 # Check if all LFS files are in place
 git rev-parse &>/dev/null
 if [[ $? -eq 0 ]]; then
-    LFS_FILES_STATUS=$(cd $ISAAC_ROS_DEV_DIR && git lfs ls-files | cut -d ' ' -f2)
+    LFS_FILES_STATUS=$(cd "$ISAAC_ROS_DEV_DIR/src/isaac_ros_common" && git lfs ls-files | cut -d ' ' -f2)
     for (( i=0; i<${#LFS_FILES_STATUS}; i++ )); do
         f="${LFS_FILES_STATUS:$i:1}"
         if [[ "$f" == "-" ]]; then
@@ -181,7 +181,7 @@ docker run -it --rm \
     --privileged \
     --network host \
     ${DOCKER_ARGS[@]} \
-    -v $ISAAC_ROS_DEV_DIR:/workspaces/isaac_ros-dev \
+    -v "$ISAAC_ROS_DEV_DIR":/workspaces/isaac_ros-dev \
     -v /dev/*:/dev/* \
     -v /etc/localtime:/etc/localtime:ro \
     --name "$CONTAINER_NAME" \

--- a/scripts/run_dev.sh
+++ b/scripts/run_dev.sh
@@ -26,7 +26,7 @@ fi
 
 ISAAC_ROS_DEV_DIR="$1"
 if [[ -z "$ISAAC_ROS_DEV_DIR" ]]; then
-    ISAAC_ROS_DEV_DIR_DEFAULTS=("$HOME/workspaces/isaac_ros-dev" "/workspaces/isaac_ros-dev")
+    ISAAC_ROS_DEV_DIR_DEFAULTS=("$HOME/workspaces/isaac_ros-dev" "/ssd/workspaces/isaac_ros-dev")
     for ISAAC_ROS_DEV_DIR in "${ISAAC_ROS_DEV_DIR_DEFAULTS[@]}"
     do
         if [[ -d "$ISAAC_ROS_DEV_DIR" ]]; then
@@ -35,7 +35,7 @@ if [[ -z "$ISAAC_ROS_DEV_DIR" ]]; then
     done
 
     if [[ ! -d "$ISAAC_ROS_DEV_DIR" ]]; then
-        ISAAC_ROS_DEV_DIR=$(realpath "$ROOT/../../")
+        ISAAC_ROS_DEV_DIR=$(realpath "$ROOT/../../../")
     fi
     print_warning "isaac_ros_dev not specified, assuming $ISAAC_ROS_DEV_DIR"
 else
@@ -93,7 +93,7 @@ fi
 cd $ROOT
 git rev-parse &>/dev/null
 if [[ $? -eq 0 ]]; then
-    LFS_FILES_STATUS=$(cd $ISAAC_ROS_DEV_DIR && git lfs ls-files | cut -d ' ' -f2)
+    LFS_FILES_STATUS=$(cd "$ROOT/.." && git lfs ls-files | cut -d ' ' -f2)
     for (( i=0; i<${#LFS_FILES_STATUS}; i++ )); do
         f="${LFS_FILES_STATUS:$i:1}"
         if [[ "$f" == "-" ]]; then

--- a/scripts/run_dev.sh
+++ b/scripts/run_dev.sh
@@ -9,7 +9,7 @@
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-source $ROOT/utils/print_color.sh
+source "$ROOT/utils/print_color.sh"
 
 function usage() {
     print_info "Usage: run_dev.sh" {isaac_ros_dev directory path OPTIONAL}
@@ -56,7 +56,7 @@ function cleanup {
 trap cleanup EXIT
 
 pushd . >/dev/null
-cd $ROOT
+cd "$ROOT"
 ON_EXIT+=("popd")
 
 # Prevent running as root.
@@ -90,7 +90,7 @@ if [[ $? -ne 0 ]] ; then
 fi
 
 # Check if all LFS files are in place in the repository where this script is running from.
-cd $ROOT
+cd "$ROOT"
 git rev-parse &>/dev/null
 if [[ $? -eq 0 ]]; then
     LFS_FILES_STATUS=$(cd "$ROOT/.." && git lfs ls-files | cut -d ' ' -f2)
@@ -137,7 +137,7 @@ if [[ ! -z "${IMAGE_KEY}" ]]; then
 fi
 
 print_info "Building $BASE_IMAGE_KEY base as image: $BASE_NAME using key $BASE_IMAGE_KEY"
-$ROOT/build_base_image.sh $BASE_IMAGE_KEY $BASE_NAME '' '' ''
+"$ROOT/build_base_image.sh" $BASE_IMAGE_KEY $BASE_NAME '' '' ''
 
 if [ $? -ne 0 ]; then
     print_error "Failed to build base image: $BASE_NAME, aborting."
@@ -194,7 +194,7 @@ docker run -it --rm \
     --privileged \
     --network host \
     ${DOCKER_ARGS[@]} \
-    -v $ISAAC_ROS_DEV_DIR:/workspaces/isaac_ros-dev \
+    -v "$ISAAC_ROS_DEV_DIR":/workspaces/isaac_ros-dev \
     -v /dev/*:/dev/* \
     -v /etc/localtime:/etc/localtime:ro \
     --name "$CONTAINER_NAME" \


### PR DESCRIPTION
Originally, the `ISAAC_ROS_DEV_DIR` variable will be incorrectly set to `$(pwd)`, i.e., `<SOME_PATH>/isaac_ros-dev/src/isaac_ros_common`, when launching the script with:

```sh
cd <SOME_PATH>/isaac_ros-dev/src/isaac_ros_common && \
  ./scripts/run_dev.sh
```

The correct path should be `<SOME_PATH>/isaac_ros-dev`, which is fixed in this commit using related path to script: `$ROOT/../../..`, i.e., `<SOME_PATH>/isaac_ros-dev/src/isaac_ros_common/scripts/../../..`.

The `LFS_FILES_STATUS` should be fixed accordingly by `cd` into `$ISAAC_ROS_DEV_DIR/src/isaac_ros_common` before checking the git lfs status.

Double quotation marks are required to correctly mount paths with special characters. (Tested with paths including whitespace characters)