### PR TITLE
Source workspace

### DIFF
--- a/docker/scripts/workspace-entrypoint.sh
+++ b/docker/scripts/workspace-entrypoint.sh
@@ -12,6 +12,7 @@
 echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> ~/.bashrc
 source /opt/ros/${ROS_DISTRO}/setup.bash
 
+# source workspace
 WORKDIR_INSTALL="/workspaces/isaac_ros-dev/install"
 if [ -d ${WORKDIR_INSTALL} ]; then
     echo "source ${WORKDIR_INSTALL}/setup.bash" >> ~/.bashrc

--- a/docker/scripts/workspace-entrypoint.sh
+++ b/docker/scripts/workspace-entrypoint.sh
@@ -12,6 +12,13 @@
 echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> ~/.bashrc
 source /opt/ros/${ROS_DISTRO}/setup.bash
 
+WORKDIR_INSTALL="/workspaces/isaac_ros-dev/install"
+if [ -d ${WORKDIR_INSTALL} ]; then
+    echo "source ${WORKDIR_INSTALL}/setup.bash" >> ~/.bashrc
+    chmod +x ${WORKDIR_INSTALL}/*.bash
+    source ${WORKDIR_INSTALL}/setup.bash
+fi
+
 sudo apt-get update
 rosdep update
 


### PR DESCRIPTION
Users previously had to input the `source /workspaces/isaac_ros-dev/install/setup.bash` command once after building or when opening a second terminal. This was causing a decrease in UX/productivity. To address this issue, we have implemented a solution. Specifically, if there is an "install" directory located directly under the "workspace" directory, it will be automatically sourced.