### PR TITLE
Fix configured search dirs variable to prepend the absolute paths

### DIFF
--- a/scripts/build_base_image.sh
+++ b/scripts/build_base_image.sh
@@ -29,7 +29,7 @@ if [[ -f "${ROOT}/.isaac_ros_common-config" ]]; then
     # Prepend configured docker search dirs
     if [ ${#CONFIG_DOCKER_SEARCH_DIRS[@]} -gt 0 ]; then
         for (( i=${#CONFIG_DOCKER_SEARCH_DIRS[@]}-1 ; i>=0 ; i-- )); do
-            if [[ "${CONFIG_DOCKER_SEARCH_DIRS[i]}" != '/*'* ]]; then
+            if [[ "${CONFIG_DOCKER_SEARCH_DIRS[i]}" != '/'* ]]; then
                 CONFIG_DOCKER_SEARCH_DIRS[$i]="${ROOT}/${CONFIG_DOCKER_SEARCH_DIRS[i]}"
             fi
         done


### PR DESCRIPTION
There is a typo in checking if the docker search path is absolute or not. Corrected the bash if condition from  ```if [[ "${CONFIG_DOCKER_SEARCH_DIRS[i]}" != '/*'* ]]```  to ```if [[ "${CONFIG_DOCKER_SEARCH_DIRS[i]}" != '/'* ]]```, (i.e) changing to '/'* without * inside the ' '.