### PR TITLE
Add depthai support

### DIFF
--- a/docker/Dockerfile.depthai
+++ b/docker/Dockerfile.depthai
@@ -1,0 +1,17 @@
+# Dockerfile for setting up Realsense driver
+#  https://github.com/jetsonhacks/installRealSenseSDK
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test && \
+    apt-get update && \
+    apt-get install -y gcc-11 \
+      g++-11 \
+      libgstreamer1.0-dev \
+      libgstreamer-plugins-base1.0-dev \
+      libusb-1.0-0-dev\
+      udev
+
+# Copy custom udev rules file
+COPY udev_rules/80-movidius.rules /etc/udev/rules.d/80-movidius.rules

--- a/docker/Dockerfile.depthai
+++ b/docker/Dockerfile.depthai
@@ -1,17 +1,5 @@
-# Dockerfile for setting up Realsense driver
-#  https://github.com/jetsonhacks/installRealSenseSDK
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-
-RUN add-apt-repository ppa:ubuntu-toolchain-r/test && \
-    apt-get update && \
-    apt-get install -y gcc-11 \
-      g++-11 \
-      libgstreamer1.0-dev \
-      libgstreamer-plugins-base1.0-dev \
-      libusb-1.0-0-dev\
-      udev
-
-# Copy custom udev rules file
-COPY udev_rules/80-movidius.rules /etc/udev/rules.d/80-movidius.rules
+RUN wget -qO- https://docs.luxonis.com/install_dependencies.sh | bash
+RUN apt install -y libusb-1.0-0-dev

--- a/docker/udev_rules/80-movidius.rules
+++ b/docker/udev_rules/80-movidius.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="usb", ATTRS{idVendor}=="03e7", MODE="0666", GROUP:="plugdev"


### PR DESCRIPTION
Hi, this one adds Dockerfile for OAK cameras. One additional thing is that to properly detect a camera, `./run_dev.sh` needs to be run with `-v /dev/bus/usb:/dev/bus/usb` option. I've added this information in isaac_ros_visual_slam Depthai Readme. 