### PR TITLE
Fix outdated kitware apt key in the isaac ros2 base image

### DIFF
--- a/docker/Dockerfile.aarch64.ros2_humble
+++ b/docker/Dockerfile.aarch64.ros2_humble
@@ -7,3 +7,7 @@
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 
 FROM nvcr.io/nvidia/isaac/ros:aarch64-ros2_humble_42f50fd45227c63eb74af1d69ddc2970
+
+# Fix kitware apt key
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null \
+    && echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null

--- a/docker/Dockerfile.x86_64.ros2_humble
+++ b/docker/Dockerfile.x86_64.ros2_humble
@@ -7,3 +7,7 @@
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 
 FROM nvcr.io/nvidia/isaac/ros:x86_64-ros2_humble_f70fbf3e86d9ae99b527f8cc2c40007b
+
+# Fix kitware apt key
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null \
+    && echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null


### PR DESCRIPTION
Apt produces the following warning when operating upon the nvcr.io/nvidia/isaac/ros:aarch64-ros2_humble_42f50fd45227c63eb74af1d69ddc2970 base image:

> W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: https://apt.kitware.com/ubuntu focal InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 1A127079A92F09ED
W: Failed to fetch https://apt.kitware.com/ubuntu/dists/focal/InRelease  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 1A127079A92F09ED
W: Some index files failed to download. They have been ignored, or old ones used instead.

To resolve the issue, I have applied the proposed fix discussed in https://github.com/dusty-nv/jetson-containers/issues/216 immediately after the base image is pulled.

This change may be reverted when resolved in the upstream base image.