### PR TITLE
run_dev.sh: Enable tests to fail gracefully

### DIFF
--- a/scripts/run_dev.sh
+++ b/scripts/run_dev.sh
@@ -138,16 +138,22 @@ if [[ -z "$(docker ps)" ]] ;  then
 fi
 
 # Check if git-lfs is installed.
+set +e
 git lfs &>/dev/null
-if [[ $? -ne 0 ]] ; then
+ECODE=$?
+set -e
+if [[ $ECODE -ne 0 ]] ; then
     print_error "git-lfs is not insalled. Please make sure git-lfs is installed before you clone the repo."
     exit 1
 fi
 
 # Check if all LFS files are in place in the repository where this script is running from.
 cd $ROOT
+set +e
 git rev-parse &>/dev/null
-if [[ $? -eq 0 ]]; then
+ECODE=$?
+set -e
+if [[ $ECODE -eq 0 ]]; then
     LFS_FILES_STATUS=$(cd $ISAAC_ROS_DEV_DIR && git lfs ls-files | cut -d ' ' -f2)
     for (( i=0; i<${#LFS_FILES_STATUS}; i++ )); do
         f="${LFS_FILES_STATUS:$i:1}"


### PR DESCRIPTION
### Issue

When following the [issac_ros_nvblox quickstart tutorial](https://nvidia-isaac-ros.github.io/repositories_and_packages/isaac_ros_nvblox/isaac_ros_nvblox/index.html#quickstart)  the verification of host setup (e.g., checking to see if git-lfs is installed) fail silently.  This is because of the `set -e` fail fast option which exits before the output to stdout.

### Fix

I added edits to two of the obvious checks that will fail silently enabling them to provide the desired reporting to stdout.

