### PR TITLE
update boost source url

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -364,7 +364,7 @@ ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/opt/tritonserver/lib"
 # Current libboost-dev apt packages are < 1.78, so install from tar.gz
 RUN --mount=type=cache,target=/var/cache/apt \
     wget -O /tmp/boost.tar.gz \
-    https://boostorg.jfrog.io/artifactory/main/release/1.80.0/source/boost_1_80_0.tar.gz \
+    https://archives.boost.io/release/1.80.0/source/boost_1_80_0.tar.gz \
     && (cd /tmp && tar xzf boost.tar.gz) \
     && cd /tmp/boost_1_80_0 \
     && ./bootstrap.sh --prefix=/usr \


### PR DESCRIPTION
When setting up my environment I found that the boost archive was moved. I've updated the url based on [this comment](https://github.com/boostorg/boost/issues/996#issuecomment-2567031602).