### PR TITLE
added PROJECT_ROOT handling for project-based isaac configs

### DIFF
--- a/scripts/build_image_layers.sh
+++ b/scripts/build_image_layers.sh
@@ -40,6 +40,14 @@ if [[ -f ~/.isaac_ros_common-config ]]; then
     . ~/.isaac_ros_common-config
 fi
 
+# Override with config from project directory if exists (and is defined)
+if [[ ! -z "${PROJECT_ROOT}" ]]; then
+    print_info "Sourcing project config at: ${PROJECT_ROOT}"
+    if [[ -f "${PROJECT_ROOT}/.isaac_ros_common-config" ]]; then
+        . "${PROJECT_ROOT}/.isaac_ros_common-config"
+    fi
+fi
+
 # Prepend configured docker search dirs
 if [ ${#CONFIG_DOCKER_SEARCH_DIRS[@]} -gt 0 ]; then
     for (( i=${#CONFIG_DOCKER_SEARCH_DIRS[@]}-1 ; i>=0 ; i-- )); do

--- a/scripts/run_dev.sh
+++ b/scripts/run_dev.sh
@@ -33,6 +33,17 @@ if [[ -f ~/.isaac_ros_common-config ]]; then
     . ~/.isaac_ros_common-config
 fi
 
+# Override with config from project directory if exists (and is defined)
+if [[ ! -z "${PROJECT_ROOT}" ]]; then
+    print_info "Sourcing project config at: ${PROJECT_ROOT}"
+    if [[ -f "${PROJECT_ROOT}/.isaac_ros_common-config" ]]; then
+        . "${PROJECT_ROOT}/.isaac_ros_common-config"
+    fi
+
+    # Make the project root available to nested scripts, eg. build_image_layers.sh
+    export PROJECT_ROOT="${PROJECT_ROOT}"
+fi
+
 # Parse command-line args
 IMAGE_KEY=ros2_humble
 


### PR DESCRIPTION
could be useful if you want to use different configs for each project (which calls run_dev.sh)