### PR TITLE
fix(docker): Resolve Python packaging build failure for aarch64

### DIFF
--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -135,6 +135,7 @@ RUN python3 -m pip install -U \
     ninja 
 
 # Additional Python dependencies
+RUN python3 -m pip install --upgrade pip setuptools packaging
 RUN python3 -m pip install -U \
     pymongo \
     scikit-learn \


### PR DESCRIPTION
The aarch64 Docker build fails during pip install when building mapbox-earcut (a trimesh dependency). This is caused by an outdated Python packaging library in the base image that's incompatible with modern package build requirements, resulting in a TypeError.

This PR resolves the issue by adding a preliminary RUN command to upgrade pip, setuptools, and packaging before other dependencies are installed.