### PR TITLE
Fix(run_dev.sh): Gracefully handle uninstalled 'git-lfs' under 'set -e'

### DIFF
--- a/scripts/run_dev.sh
+++ b/scripts/run_dev.sh
@@ -138,8 +138,7 @@ if [[ -z "$(docker ps)" ]] ;  then
 fi
 
 # Check if git-lfs is installed.
-git lfs &>/dev/null
-if [[ $? -ne 0 ]] ; then
+if ! git lfs &>/dev/null; then
     print_error "git-lfs is not insalled. Please make sure git-lfs is installed before you clone the repo."
     exit 1
 fi


### PR DESCRIPTION
The script was prematurely exiting if the user did not have 'git-lfs' installed, due to a conflict with the global 'set -e' directive.

The original check was a bare command: `git lfs &>/dev/null`. Since the script uses `set -e` (which causes the script to exit immediately if any command returns a non-zero status), if `git lfs` was not found (or failed), it would return a non-zero status. This caused the entire script to abort immediately without executing the intended error handling logic. This resulted in a silent or confusing failure for the user.

The check has been refactored into an explicit conditional block:

```bash
if ! git lfs &>/dev/null; then
    print_error "git-lfs is not insalled. Please make sure git-lfs is installed before you clone the repo."
    exit 1
fi
```
By wrapping the check in `if ! ...; then`, the exit status of `git lfs` is explicitly handled by the `if` statement. This prevents `set -e` from prematurely exiting the script and ensures that the script prints the intended, user-friendly error message before exiting with status 1.