### PR TITLE
Fix git-lfs check to display error message

### DIFF
--- a/scripts/run_dev.sh
+++ b/scripts/run_dev.sh
@@ -138,9 +138,8 @@ if [[ -z "$(docker ps)" ]] ;  then
 fi
 
 # Check if git-lfs is installed.
-git lfs &>/dev/null
-if [[ $? -ne 0 ]] ; then
-    print_error "git-lfs is not insalled. Please make sure git-lfs is installed before you clone the repo."
+if ! git lfs &>/dev/null; then
+    print_error "git-lfs is not installed. Please make sure git-lfs is installed before you clone the repo."
     exit 1
 fi
 


### PR DESCRIPTION
Not sure if you accept patches on releases, but I don't think this applies to the latest version.

## Summary

- Fixes the git-lfs installation check that silently exits without showing an error message
- The previous code used `git lfs &>/dev/null` followed by checking `$?`, but since the script uses `set -e`, the script exits immediately on the non-zero return code before reaching the `print_error` call

## Root Cause

```bash
set -e  # line 11

git lfs &>/dev/null        # exits here with code 1
if [[ $? -ne 0 ]] ; then   # never reached
    print_error "..."      # never printed
fi
```

## Fix

```bash
if ! git lfs &>/dev/null; then
    print_error "..."
fi
```

Fixes #151, #167, #176